### PR TITLE
Remove the delay CLI parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ python gb-api-mirror.py <path to save files>
 
 ### Options
 
-* `--delay SECONDS` Delay between the requests (in seconds)
 * `--images` Also download the images
 * `--include RESOURCES` Comma-separated list of the resources to download (defaults to all)
 * `--overwrite-images` Overwrite existing images (by default it doesn't download ones that exist)

--- a/gb-api-mirror.py
+++ b/gb-api-mirror.py
@@ -17,14 +17,6 @@ if __name__ == "__main__":
         help="directory to store the data in",
     )
     parser.add_argument(
-        "-d",
-        "--delay",
-        type=int,
-        default=20,  # ~200 requests per hour
-        metavar="SECONDS",
-        help="time to delay between requests (default: 20)",
-    )
-    parser.add_argument(
         "-f",
         "--images",
         help="download images alongside metadata",
@@ -94,7 +86,7 @@ if __name__ == "__main__":
             continue
 
         logger.info(f"Downloading {resource}...")
-        data = resource.download_data(api_key, args.delay)
+        data = resource.download_data(api_key)
         if len(data) == 0:
             logger.warn(f"Got 0 results for: {resource}")
             continue

--- a/utils/api.py
+++ b/utils/api.py
@@ -36,6 +36,9 @@ IMAGE_URL_PREFIXES = [
 # How many times to retry a failed GET request
 MAX_RETRIES = 10
 
+# Delay between each request (to avoid overloading the API and getting banned)
+REQUEST_DELAY = 1
+
 # How long (in seconds) to wait between retrying requests
 RETRY_DELAY = 30
 
@@ -141,9 +144,7 @@ def download_images(
     return downloaded, skipped, errors
 
 
-def get_individualized_resource(
-    resource: str, max_count: int, api_key: str, delay: int
-) -> list:
+def get_individualized_resource(resource: str, max_count: int, api_key: str) -> list:
     """Get a resource that needs to be fetched one entry at a time."""
     base_url = f"{BASE_URL}/{resource}"
     params = {
@@ -167,12 +168,12 @@ def get_individualized_resource(
         if num > max_count:
             break
 
-        sleep(delay)
+        sleep(REQUEST_DELAY)
 
     return results
 
 
-def get_paged_resource(resource: str, api_key: str, delay: int) -> list:
+def get_paged_resource(resource: str, api_key: str) -> list:
     """Get a resource that's paged with limit/offset parameters."""
     resources = []
     offset = 0
@@ -184,7 +185,7 @@ def get_paged_resource(resource: str, api_key: str, delay: int) -> list:
         resources += results
         offset += PAGE_REQUEST_LIMIT
 
-        sleep(delay)
+        sleep(REQUEST_DELAY)
 
     return resources
 

--- a/utils/resource.py
+++ b/utils/resource.py
@@ -58,7 +58,7 @@ class Resource(StrEnum):
     VIDEO_TYPES = "video_types"
     VIDEOS = "videos"
 
-    def download_data(self, api_key: str, delay: int) -> list:
+    def download_data(self, api_key: str) -> list:
         """Download data for this resource."""
         data = []
 
@@ -88,9 +88,9 @@ class Resource(StrEnum):
             Resource.VIDEO_TYPES,
             Resource.VIDEOS,
         ]:
-            data = api.get_paged_resource(self.value, api_key, delay)
+            data = api.get_paged_resource(self.value, api_key)
         elif self == Resource.REVIEWS:
-            data = api.get_individualized_resource("review", 1000, api_key, delay)
+            data = api.get_individualized_resource("review", 1000, api_key)
         elif self == Resource.TYPES:
             data = api.get_resource(self.value, api_key)
         else:


### PR DESCRIPTION
After some testing and tweaking I've decided to remove this and hard-code a delay of 1 second between each request. This is done mainly to avoid overloading the API which has "implement[ed] velocity detection to prevent malicious use" and may get angry if you send too many requests.

The rate limiting is done per resource and most resources have fewer than 200 pages worth of data, so having a delay apply to everything was just slowing everything down. Now instead of delaying every request it checks if an error response was due to the rate limit (status code `420`) and then waits for 10 minutes. This will allow the limiter to be reset without hammering it too often.